### PR TITLE
Association of Boxing Commissions

### DIFF
--- a/cooperatives/association-of-boxing-commissions.md
+++ b/cooperatives/association-of-boxing-commissions.md
@@ -1,0 +1,38 @@
+---
+title: Association of Boxing Commissions
+parent: Cooperatives
+---
+
+# Association of Boxing Commissions
+
+|                   |                                          |
+|:------------------|:-----------------------------------------|
+| model             | Collaborative Organizational Development
+| service type      | Occupational Licensing
+| country           | United States
+| states            | AK, AL, AR, AZ, CA, CO, CT, DE, FL, GA, HI, IA, ID, IL, IN, KS, KY, LA, MA, MD, ME, MI, MN, MO, MS, MT, NC, ND, NE, NH, NJ, NM, NV, NY, OH, OK, OR, PA, RI, SC, SD, TN, TX, UT, VA, VT, WA, WI, WV, WY, DC, PR
+| government type   | state
+| license           | closed
+| website           | [www.abcboxing.com](https://www.abcboxing.com/)
+| Wikipedia entry   | [en.wikipedia.org/wiki/Association_of_Boxing_Commissions](https://en.wikipedia.org/wiki/Association_of_Boxing_Commissions)
+
+## Description
+The Association of Boxing Commissions, also known as the Association of Boxing Commissions and Combative Sports, is open to, "each of the states of the United States of America, the District of Columbia, Puerto Rico, the U.S. Virgin Islands, and any federally recognized Indian tribe which has formed a tribal organization to regulate professional boxing matches pursuant to 15 USC § 6312(b)."  It also appears to incorporate Canadian authorities, although not as voting members.
+
+Its mission is:
+
+> (A) To promote the continual improvement of, and for, professional boxing; professional and amateur mixed martial arts; and other professional and amateur unarmed combat sports (hereinafter, “combat sports”).
+
+> (B) To promote the uniformity of health and safety standards and other requirements pertaining to the conduct of combat sports events.
+
+> (C) To promote standard reporting of combat sports events between members, including results, injury reports, suspensions and other medical information.
+
+> (D) To encourage communication, cooperation and uniformity in the supervision and regulation of combat sports among the members of the ABC.
+
+> (E) To publish and disseminate medical and training information, and to promote and hold seminars for the continuing education of all officials, ringside physicians, commissioners and commission employees.
+
+> (F) To establish and operate a charitable foundation which will accept donations to a charitable fund for indigent boxers with elected officers and members of the ABC Board of Directors serving on the board of governors and as trustees of this fund.
+
+> (G) To encourage adherence to, and enforcement of, applicable federal laws by each member of the ABC.
+
+The association maintains website to disseminate standards, policies, and documents it produces. It also designates an official "record keeper" organizations to maintain shared records about combat sports events regulated by its member agencies. Agencies rely on these records as part of their licensing and oversight functions.  For professional boxing, the association has designated [BoxRec](https://boxrec.com/) to maintain official records. For mixed martial arts, the commission uses [MMARegistry](https://www.mmareg.com/), which is maintained by [MixedMartialArts.com](https://www.mixedmartialarts.com/). These organizations maintain the data both for their own commercial purposes (i.e. to operate sports statistics sites) and under contracts with the association to meet its record-keeping and regulatory needs.


### PR DESCRIPTION
The Association of Boxing Commissions, which coordinates the work of all the state, provincial (Canadian), and tribal authorities that regulate boxing and mixed martial arts, contracts with sports statistics sites to maintain official registries that regulators use to support their work.